### PR TITLE
Draggable element fix for FireFox

### DIFF
--- a/app/components/Caption.jsx
+++ b/app/components/Caption.jsx
@@ -79,6 +79,7 @@ export default class Caption extends BaseComponent {
   }
 
   _handleDragStart(e, ui) {
+    e.preventDefault();
     this._startDrag = ui.position;
     this._startPosition = {
       x: this.state.x,

--- a/app/components/Edge.jsx
+++ b/app/components/Edge.jsx
@@ -86,6 +86,7 @@ export default class Edge extends BaseComponent {
   }
 
   _handleDragStart(event, ui) {
+    event.preventDefault();
     this._startDrag = ui.position;
     this._startPosition = {
       x: this.state.cx,

--- a/app/components/Node.jsx
+++ b/app/components/Node.jsx
@@ -28,7 +28,7 @@ export default class Node extends BaseComponent {
         moveOnStartChange={false}
         onStart={this._handleDragStart}
         onDrag={this._handleDrag}
-        onStop={this._handleDragStop}>
+        onStop={this._handleDragStop} >
         <g 
           id={groupId} 
           className="node" 
@@ -53,6 +53,7 @@ export default class Node extends BaseComponent {
 
   // keep initial position for comparison with drag position
   _handleDragStart(e, ui) {
+    e.preventDefault();
     this._startDrag = ui.position;
     this._startPosition = {
       x: this.state.x,


### PR DESCRIPTION
Closes #29. 

There was an error where dragging SVG graph elements (i.e. nodes, edges and captions -- to the exclusion of nodes containing images) was producing buggy behaviour in Firefox (47.0).

Simply adding `e.preventDefault()` to the beginning of all these components's '_handleDragStart()' seems to fix the issue.

My best guess is the issue was caused by an update to react-draggable or another library.
