### PR TITLE
Edge dropdown menu

### DIFF
--- a/app/components/Edge.jsx
+++ b/app/components/Edge.jsx
@@ -17,6 +17,8 @@ export default class Edge extends BaseComponent {
   }
 
   render() {
+    console.log(this.state);
+
     let e = this.props.edge;
     let sp = this._getSvgParams(e);
     let width = 1 + (e.display.scale - 1) * 5;

--- a/app/components/Edge.jsx
+++ b/app/components/Edge.jsx
@@ -25,7 +25,7 @@ export default class Edge extends BaseComponent {
   }
 
   componentDidMount(){
-     if (includes(["left", "right", "both"], this.props.edge.display.arrow)){
+    if (includes(["left", "right", "both"], this.props.edge.display.arrow)){
       this.props.updateArrow(this.props.edge);
     }
   }

--- a/app/components/Edge.jsx
+++ b/app/components/Edge.jsx
@@ -2,22 +2,35 @@ import React, { Component, PropTypes } from 'react';
 import BaseComponent from './BaseComponent';
 import { DraggableCore } from 'react-draggable';
 import merge from 'lodash/merge';
+import includes from 'lodash/includes';
 import eds from '../EdgeDisplaySettings';
 import nds from '../NodeDisplaySettings';
 import classNames from 'classnames';
 import { calculateDeltas } from  '../helpers';
+
+const noUpdateValues = [false, 0, null, "left", "right", "both"];
 
 export default class Edge extends BaseComponent {
   constructor(props) {
     super(props);
     this.bindAll('_handleDragStart', '_handleDrag', '_handleDragStop', '_handleClick', '_handleTextClick');
     // need control point immediately for dragging
-    let { cx, cy } = this._calculateGeometry(props.edge.display);
+    let { cx, cy, is_reverse } = this._calculateGeometry(props.edge.display);
+    if (!includes(noUpdateValues, this.props.edge.display.arrow)){
+      this.props.getArrow(is_reverse, this.props.edge);
+    }
+
     this.state = merge({}, props.edge.display, { cx, cy });
+
+  }
+
+  componentDidMount(){
+     if (includes(["left", "right", "both"], this.props.edge.display.arrow)){
+      this.props.updateArrow(this.props.edge);
+    }
   }
 
   render() {
-    console.log(this.state);
 
     let e = this.props.edge;
     let sp = this._getSvgParams(e);
@@ -80,6 +93,7 @@ export default class Edge extends BaseComponent {
   componentWillReceiveProps(props) {
     let newState = merge({ label: null, url: null }, props.edge.display);
     this.setState(newState);
+
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -131,7 +145,6 @@ export default class Edge extends BaseComponent {
     let e = edge;
     let { label, scale, arrow, dash, status } = this.state;
     let { x, y, cx, cy, xa, ya, xb, yb, is_reverse } = this._calculateGeometry(this.state);
-
     const pathId = `path-${e.id}`;
     const fontSize = 10 * Math.sqrt(scale);
 
@@ -143,8 +156,8 @@ export default class Edge extends BaseComponent {
       fontSize: fontSize,
       dy: -6 * Math.sqrt(scale),
       textPath: { __html: `<textPath class="labelpath" startOffset="50%" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#${pathId}" font-size="${fontSize}">${label}</textPath>` },
-      markerStart: (arrow && is_reverse) ? "url(#marker2)" : "",
-      markerEnd: (arrow && !is_reverse) ? "url(#marker1)" : "",
+      markerStart: (arrow == "left" || arrow == "both") ? "url(#marker2)" : "",
+      markerEnd: (arrow == "right" || arrow == "both") ? "url(#marker1)" : "",
       lineColor: eds.lineColor[status],
       textColor: eds.textColor[status],
       bgColor: eds.bgColor[status],

--- a/app/components/EdgeArrowSelector.jsx
+++ b/app/components/EdgeArrowSelector.jsx
@@ -1,0 +1,68 @@
+import React, { Component, PropTypes } from 'react';
+import BaseComponent from './BaseComponent';
+import { newArrowState } from '../helpers';
+import capitalize from 'lodash/capitalize';
+
+export default class EdgeArrowSelector extends BaseComponent {
+  
+   constructor() {
+      super();
+      this.state = { isOpen: false };
+      this.bindAll('_updateArrow', '_arrowClass');
+   }
+
+   render() {
+       let { arrowSide }  = this.props;
+       return(
+            <div className ="dropdownHolder arrowHead">
+                <div className ="selectedEdgeDisplay svgDropdown"
+                     onClick={ () => this.setState({isOpen: true})} >
+                    <div className = {this._arrowClass()}>
+                        <svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
+                    </div>
+                </div>
+                { this.state.isOpen &&
+                  <ul className={"svgDropdown edgeDropdownOptions"}>
+	              <li className={`svgDropdown${capitalize(arrowSide)}NoArrow`}
+                          onClick={ () => this._updateArrow(false) }>
+	                  <svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
+	              </li>
+	              <li className={`svgDropdown${capitalize(arrowSide)}Arrow`}
+                          onClick={ () => this._updateArrow(true) }>
+	                  <svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
+	              </li>
+                  </ul>
+                } </div>)
+  }
+
+    _arrowClass() {
+        let { arrow, arrowSide } = this.props;
+        if (arrow === arrowSide || arrow === 'both'){
+            return `svgDropdown${capitalize(arrowSide)}Arrow`
+        } else {
+            return '';
+        }
+    }
+
+    _updateArrow(showArrow) {
+        const oldArrowState = this.props.arrow;
+        const arrowSide = this.props.arrowSide;
+        const _newArrowState = newArrowState(oldArrowState, arrowSide, showArrow)
+        if (oldArrowState !== _newArrowState) {
+            this.props.updateEdge(this.props.edgeId, {display: {arrow: _newArrowState }});
+        }
+        this.setState({isOpen: false});
+    }
+
+}
+
+/* 
+   arrowSide must be exactly 'left' or 'right'
+   Possible arrow states: 'left', 'right', 'both', false/true
+*/
+EdgeArrowSelector.propTypes = {
+    updateEdge: PropTypes.func.isRequired,
+    edgeId: PropTypes.any.isRequired,
+    arrowSide: PropTypes.string.isRequired,
+    arrow: PropTypes.any
+};

--- a/app/components/EdgeDashSelector.jsx
+++ b/app/components/EdgeDashSelector.jsx
@@ -1,0 +1,53 @@
+import React, { Component, PropTypes } from 'react';
+import BaseComponent from './BaseComponent';
+
+export default class EdgeDashSelector extends BaseComponent {
+
+  constructor(){
+      super();
+      this.state = { isOpen: false };
+      this.bindAll('_menuOptions', '_updateEdge');
+  }
+  
+  render(){
+    return(
+        <div className ="dropdownHolder strokeMain">
+            <div className ="selectedEdgeDisplay svgDropdown">
+                <div 
+                    className = {this.props.isDashed ? "svgDropdownDashed" : ""  } 
+                    onClick={ () => this.setState({isOpen: true})} >
+                    <svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
+                </div>
+                {this.state.isOpen && this._menuOptions() }
+            </div>
+        </div> )
+  }
+
+    _menuOptions(){
+        return (
+            <ul className={"svgDropdown edgeDropdownOptions"}>
+                <li className="svgDropdownUndashed"
+                    onClick={() => this._updateEdge(false) } >
+                    <svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
+                </li>
+                <li className="svgDropdownDashed" 
+                    onClick={() => this._updateEdge(true) } >
+                    <svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
+                </li>
+            </ul>
+        )
+    }
+    
+    _updateEdge(newDashState) {
+        let { updateEdge, edgeId} = this.props;
+        updateEdge(edgeId, {display: {dash: newDashState }});
+        this.setState({isOpen: false});
+    }
+    
+}
+
+EdgeDashSelector.propTypes = {
+  isDashed: PropTypes.bool.isRequired,
+  updateEdge: PropTypes.func.isRequired,
+  edgeId: PropTypes.any.isRequired   
+};

--- a/app/components/EdgeDropdown.jsx
+++ b/app/components/EdgeDropdown.jsx
@@ -1,143 +1,19 @@
 import React, { Component, PropTypes } from 'react';
 import BaseComponent from './BaseComponent';
+import { legacyArrowConverter } from '../helpers';
+import EdgeArrowSelector from './EdgeArrowSelector';
+import EdgeDashSelector from './EdgeDashSelector';
 
-export default class EdgeDropdown extends BaseComponent {
-
-  constructor(props) {
-    super(props);
-    var hasLeft = (this.props.arrow == "left" || this.props.arrow == "both") ? true : false;
-    var hasRight = (this.props.arrow == "right" || this.props.arrow == "both") ? true : false;
-
-    this.state = {
-      "leftSideOpen": false,
-      "centerOpen": false, 
-      "rightSideOpen": false,
-      "leftSideArrow": hasLeft,
-      "centerDashed": props.dash, 
-      "rightSideArrow": hasRight
-    };
-  }
-
-  componentWillReceiveProps() {
-  	var hasLeft = (this.props.arrow == "left" || this.props.arrow == "both") ? true : false;
-    var hasRight = (this.props.arrow == "right" || this.props.arrow == "both") ? true : false;
-	this.setState({"leftSideArrow": hasLeft});
-    this.setState({"rightSideArrow": hasRight});
-	this.setState({"centerDashed": this.props.dash});
-  }
-
-  componentDidUpdate() {
-  	if (this.state.centerDashed != this.props.dash){
-  		this.setState({"centerDashed": this.props.dash});
-  	}
-  	var hasLeft = (this.props.arrow == "left" || this.props.arrow == "both") ? true : false;
-    var hasRight = (this.props.arrow == "right" || this.props.arrow == "both") ? true : false;
-
-	if (this.state.leftSideArrow != hasLeft){
-		this.setState({"leftSideArrow": hasLeft});
-	}
-	if (this.state.rightSideArrow != hasRight){
-		this.setState({"rightSideArrow": hasRight});
-	}
-  }
-
-
+export default class EdgeDropdown extends Component {
   render () {
-  	var leftClass = this.state.leftSideArrow ? "svgDropdownLeftArrow" : "";
-  	var centerClass = this.state.centerDashed ? "svgDropdownDashed" : "";
-  	var rightClass = this.state.rightSideArrow ? "svgDropdownRightArrow" : "";
-  	return (
-  		<div className="strokeDropdowns">
-		  	<div className ="dropdownHolder arrowHead">
-		  		<div className ="selectedEdgeDisplay svgDropdown"
-  					onClick={() => this._toggleView("leftSideOpen")}>
-  					<div className = {leftClass}>
-  						<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
-  					</div>
-  				</div>
-  				{ this.state.leftSideOpen &&
-		  			<ul className={"svgDropdown edgeDropdownOptions"}>
-		  				<li className="svgDropdownLeftNoArrow"
-		  					onClick={() => this._toggleView("leftSideOpen", ["leftSideArrow", false])}>
-		  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
-		  				</li>
-		  				<li className="svgDropdownLeftArrow"
-		  					onClick={() => this._toggleView("leftSideOpen", ["leftSideArrow", true])}>
-		  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
-		  				</li>
-		  			</ul>
-		  		}
-				</div>
-	  		<div className ="dropdownHolder strokeMain">
-	  			<div className ="selectedEdgeDisplay svgDropdown"
-  					onClick={() => this._toggleView("centerOpen")}>
-  					<div className = {centerClass}>
-  						<svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
-  					</div>
-  				</div>
-	  			{ this.state.centerOpen &&
-		  			<ul className={"svgDropdown edgeDropdownOptions"}>
-		  				<li className="svgDropdownUndashed"
-		  					onClick={() => this._toggleView("centerOpen", ["centerDashed", false])}>
-		  					<svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
-		  				</li>
-		  				<li className="svgDropdownDashed"
-		  					onClick={() => this._toggleView("centerOpen", ["centerDashed", true])}>
-		  					<svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
-		  				</li>
-		  			</ul>
-		  		}
-			</div>
-			<div className ="dropdownHolder arrowHead">
-	  			<div className ="selectedEdgeDisplay svgDropdown"
-  					onClick={() => this._toggleView("rightSideOpen")}>
-  					<div className = {rightClass}>
-  						<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
-  					</div>
-  				</div>
-				{ this.state.rightSideOpen &&
-	  			<ul className={"svgDropdown edgeDropdownOptions"}>
-	  				<li className="svgDropdownRightNoArrow"
-	  					onClick={() => this._toggleView("rightSideOpen", ["rightSideArrow", false])}>
-	  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
-	  				</li>
-	  				<li className="svgDropdownRightArrow"
-	  					onClick={() => this._toggleView("rightSideOpen", ["rightSideArrow", true])}>
-	  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
-	  				</li>
-	  			</ul>
-	  			}
-			</div>
-		</div>
-	  )
-
+      const arrow = legacyArrowConverter(this.props.arrow);
+      return (
+  	  <div className="strokeDropdowns">
+	    <EdgeArrowSelector updateEdge={this.props.updateEdge} edgeId={this.props.edgeId} arrowSide="left" arrow={arrow} />
+	    <EdgeDashSelector isDashed={Boolean(this.props.dash)} updateEdge={this.props.updateEdge} edgeId={this.props.edgeId} />
+            <EdgeArrowSelector updateEdge={this.props.updateEdge} edgeId={this.props.edgeId} arrowSide="right" arrow={arrow} />
+	  </div>
+      );
   }
+};
 
-  	_handleChange(){
-	  	var whichArrow;
-	  	if (this.state.leftSideArrow && this.state.rightSideArrow){
-	  		whichArrow = "both";
-	  	} else if (!this.state.leftSideArrow && !this.state.rightSideArrow) {
-	  		whichArrow = "none";
-	  	} else if (this.state.leftSideArrow){
-	  		whichArrow = "left";
-	  	} else {
-	  		whichArrow = "right";
-	  	}
-	  	this.props.onChange(whichArrow, this.state.centerDashed);
-  	}
-
-	_toggleView(whichView, whichProperty){
-		if (this.state[whichView]){
-			this.state[whichView] = false
-		} else {
-			this.state[whichView] = true;
-		}
-
-		if (whichProperty != undefined){
-			this.state[whichProperty[0]] = whichProperty[1];
-		}
-		this._handleChange();
-	}
-
-}

--- a/app/components/EdgeDropdown.jsx
+++ b/app/components/EdgeDropdown.jsx
@@ -1,47 +1,68 @@
 import React, { Component, PropTypes } from 'react';
 import BaseComponent from './BaseComponent';
 
-export default class Node extends BaseComponent {
+export default class EdgeDropdown extends BaseComponent {
 
   constructor(props) {
     super(props);
+    var hasLeft = (this.props.arrow == "left" || this.props.arrow == "both") ? true : false;
+    var hasRight = (this.props.arrow == "right" || this.props.arrow == "both") ? true : false;
 
     this.state = {
       "leftSideOpen": false,
       "centerOpen": false, 
       "rightSideOpen": false,
-      "leftSideArrow": false,
+      "leftSideArrow": hasLeft,
       "centerDashed": props.dash, 
-      "rightSideArrow": false
+      "rightSideArrow": hasRight
     };
   }
 
   componentWillReceiveProps() {
+  	var hasLeft = (this.props.arrow == "left" || this.props.arrow == "both") ? true : false;
+    var hasRight = (this.props.arrow == "right" || this.props.arrow == "both") ? true : false;
+	this.setState({"leftSideArrow": hasLeft});
+    this.setState({"rightSideArrow": hasRight});
 	this.setState({"centerDashed": this.props.dash});
+  }
+
+  componentDidUpdate() {
+  	if (this.state.centerDashed != this.props.dash){
+  		this.setState({"centerDashed": this.props.dash});
+  	}
+  	var hasLeft = (this.props.arrow == "left" || this.props.arrow == "both") ? true : false;
+    var hasRight = (this.props.arrow == "right" || this.props.arrow == "both") ? true : false;
+	
+	if (this.state.leftSideArrow != hasLeft){
+		this.setState({"leftSideArrow": hasLeft});
+	}
+	if (this.state.rightSideArrow != hasRight){
+		this.setState({"rightSideArrow": hasRight});
+	}
   }
 
 
   render () {
-  	var leftClass = this.state.leftSideOpen ? "svgDropdownLeftArrow" : "";
-  	var centerClass = this.props.dash ? "svgDropdownDashed" : "";
-  	var rightClass = this.state.rightSideOpen ? "svgDropdownRightArrow" : "";
+  	var leftClass = this.state.leftSideArrow ? "svgDropdownLeftArrow" : "";
+  	var centerClass = this.state.centerDashed ? "svgDropdownDashed" : "";
+  	var rightClass = this.state.rightSideArrow ? "svgDropdownRightArrow" : "";
   	return (
   		<div className="strokeDropdowns">
 		  	<div className ="dropdownHolder arrowHead">
 		  		<div className ="selectedEdgeDisplay svgDropdown"
   					onClick={() => this._toggleView("leftSideOpen")}>
-  					<div className = {""}>
+  					<div className = {leftClass}>
   						<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
   					</div>
   				</div>
   				{ this.state.leftSideOpen &&
 		  			<ul className={"svgDropdown edgeDropdownOptions"}>
 		  				<li 
-		  					onClick={() => this._toggleView("leftSideOpen")}>
+		  					onClick={() => this._toggleView("leftSideOpen", ["leftSideArrow", false])}>
 		  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
 		  				</li>
 		  				<li className="svgDropdownLeftArrow"
-		  					onClick={() => this._toggleView("leftSideOpen")}>
+		  					onClick={() => this._toggleView("leftSideOpen", ["leftSideArrow", true])}>
 		  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
 		  				</li>
 		  			</ul>
@@ -57,11 +78,11 @@ export default class Node extends BaseComponent {
 	  			{ this.state.centerOpen &&
 		  			<ul className={"svgDropdown edgeDropdownOptions"}>
 		  				<li
-		  					onClick={() => this._toggleView("centerOpen")}>
+		  					onClick={() => this._toggleView("centerOpen", ["centerDashed", false])}>
 		  					<svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
 		  				</li>
 		  				<li className="svgDropdownDashed"
-		  					onClick={() => this._toggleView("centerOpen")}>
+		  					onClick={() => this._toggleView("centerOpen", ["centerDashed", true])}>
 		  					<svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
 		  				</li>
 		  			</ul>
@@ -70,18 +91,18 @@ export default class Node extends BaseComponent {
 			<div className ="dropdownHolder arrowHead">
 	  			<div className ="selectedEdgeDisplay svgDropdown"
   					onClick={() => this._toggleView("rightSideOpen")}>
-  					<div className = {""}>
+  					<div className = {rightClass}>
   						<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
   					</div>
   				</div>
 				{ this.state.rightSideOpen &&
 	  			<ul className={"svgDropdown edgeDropdownOptions"}>
 	  				<li
-	  					onClick={() => this._toggleView("rightSideOpen")}>
+	  					onClick={() => this._toggleView("rightSideOpen", ["rightSideArrow", false])}>
 	  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
 	  				</li>
 	  				<li className="svgDropdownRightArrow"
-	  					onClick={() => this._toggleView("rightSideOpen")}>
+	  					onClick={() => this._toggleView("rightSideOpen", ["rightSideArrow", true])}>
 	  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
 	  				</li>
 	  			</ul>
@@ -92,14 +113,31 @@ export default class Node extends BaseComponent {
 
   }
 
-	_toggleView(whichView){
+  _handleChange(){
+  	var whichArrow;
+  	if (this.state.leftSideArrow && this.state.rightSideArrow){
+  		whichArrow = "both";
+  	} else if (!this.state.leftSideArrow && !this.state.rightSideArrow) {
+  		whichArrow = null;
+  	} else if (this.state.leftSideArrow){
+  		whichArrow = "left";
+  	} else {
+  		whichArrow = "right";
+  	}
+  	this.props.onChange(whichArrow, this.state.centerDashed);
+  }
+
+	_toggleView(whichView, whichProperty){
 		if (this.state[whichView]){
 			this.state[whichView] = false
 		} else {
 			this.state[whichView] = true;
 		}
 
-		this.forceUpdate();
+		if (whichProperty != undefined){
+			this.state[whichProperty[0]] = whichProperty[1];
+		}
+		this._handleChange();
 	}
 
 }

--- a/app/components/EdgeDropdown.jsx
+++ b/app/components/EdgeDropdown.jsx
@@ -1,0 +1,105 @@
+import React, { Component, PropTypes } from 'react';
+import BaseComponent from './BaseComponent';
+
+export default class Node extends BaseComponent {
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      "leftSideOpen": false,
+      "centerOpen": false, 
+      "rightSideOpen": false,
+      "leftSideArrow": false,
+      "centerDashed": props.dash, 
+      "rightSideArrow": false
+    };
+  }
+
+  componentWillReceiveProps() {
+	this.setState({"centerDashed": this.props.dash});
+  }
+
+
+  render () {
+  	var leftClass = this.state.leftSideOpen ? "svgDropdownLeftArrow" : "";
+  	var centerClass = this.props.dash ? "svgDropdownDashed" : "";
+  	var rightClass = this.state.rightSideOpen ? "svgDropdownRightArrow" : "";
+  	return (
+  		<div className="strokeDropdowns">
+		  	<div className ="dropdownHolder arrowHead">
+		  		<div className ="selectedEdgeDisplay svgDropdown"
+  					onClick={() => this._toggleView("leftSideOpen")}>
+  					<div className = {""}>
+  						<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
+  					</div>
+  				</div>
+  				{ this.state.leftSideOpen &&
+		  			<ul className={"svgDropdown edgeDropdownOptions"}>
+		  				<li 
+		  					onClick={() => this._toggleView("leftSideOpen")}>
+		  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
+		  				</li>
+		  				<li className="svgDropdownLeftArrow"
+		  					onClick={() => this._toggleView("leftSideOpen")}>
+		  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
+		  				</li>
+		  			</ul>
+		  		}
+				</div>
+	  		<div className ="dropdownHolder strokeMain">
+	  			<div className ="selectedEdgeDisplay svgDropdown"
+  					onClick={() => this._toggleView("centerOpen")}>
+  					<div className = {centerClass}>
+  						<svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
+  					</div>
+  				</div>
+	  			{ this.state.centerOpen &&
+		  			<ul className={"svgDropdown edgeDropdownOptions"}>
+		  				<li
+		  					onClick={() => this._toggleView("centerOpen")}>
+		  					<svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
+		  				</li>
+		  				<li className="svgDropdownDashed"
+		  					onClick={() => this._toggleView("centerOpen")}>
+		  					<svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
+		  				</li>
+		  			</ul>
+		  		}
+			</div>
+			<div className ="dropdownHolder arrowHead">
+	  			<div className ="selectedEdgeDisplay svgDropdown"
+  					onClick={() => this._toggleView("rightSideOpen")}>
+  					<div className = {""}>
+  						<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
+  					</div>
+  				</div>
+				{ this.state.rightSideOpen &&
+	  			<ul className={"svgDropdown edgeDropdownOptions"}>
+	  				<li
+	  					onClick={() => this._toggleView("rightSideOpen")}>
+	  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
+	  				</li>
+	  				<li className="svgDropdownRightArrow"
+	  					onClick={() => this._toggleView("rightSideOpen")}>
+	  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
+	  				</li>
+	  			</ul>
+	  			}
+			</div>
+		</div>
+	  )
+
+  }
+
+	_toggleView(whichView){
+		if (this.state[whichView]){
+			this.state[whichView] = false
+		} else {
+			this.state[whichView] = true;
+		}
+
+		this.forceUpdate();
+	}
+
+}

--- a/app/components/EdgeDropdown.jsx
+++ b/app/components/EdgeDropdown.jsx
@@ -32,7 +32,7 @@ export default class EdgeDropdown extends BaseComponent {
   	}
   	var hasLeft = (this.props.arrow == "left" || this.props.arrow == "both") ? true : false;
     var hasRight = (this.props.arrow == "right" || this.props.arrow == "both") ? true : false;
-	
+
 	if (this.state.leftSideArrow != hasLeft){
 		this.setState({"leftSideArrow": hasLeft});
 	}
@@ -57,7 +57,7 @@ export default class EdgeDropdown extends BaseComponent {
   				</div>
   				{ this.state.leftSideOpen &&
 		  			<ul className={"svgDropdown edgeDropdownOptions"}>
-		  				<li 
+		  				<li className="svgDropdownLeftNoArrow"
 		  					onClick={() => this._toggleView("leftSideOpen", ["leftSideArrow", false])}>
 		  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
 		  				</li>
@@ -77,7 +77,7 @@ export default class EdgeDropdown extends BaseComponent {
   				</div>
 	  			{ this.state.centerOpen &&
 		  			<ul className={"svgDropdown edgeDropdownOptions"}>
-		  				<li
+		  				<li className="svgDropdownUndashed"
 		  					onClick={() => this._toggleView("centerOpen", ["centerDashed", false])}>
 		  					<svg><line x1="98%" y1="50%" x2="2%" y2="50%" /></svg>
 		  				</li>
@@ -97,7 +97,7 @@ export default class EdgeDropdown extends BaseComponent {
   				</div>
 				{ this.state.rightSideOpen &&
 	  			<ul className={"svgDropdown edgeDropdownOptions"}>
-	  				<li
+	  				<li className="svgDropdownRightNoArrow"
 	  					onClick={() => this._toggleView("rightSideOpen", ["rightSideArrow", false])}>
 	  					<svg><line x1="75%" y1="50%" x2="25%" y2="50%" /></svg>
 	  				</li>
@@ -113,19 +113,19 @@ export default class EdgeDropdown extends BaseComponent {
 
   }
 
-  _handleChange(){
-  	var whichArrow;
-  	if (this.state.leftSideArrow && this.state.rightSideArrow){
-  		whichArrow = "both";
-  	} else if (!this.state.leftSideArrow && !this.state.rightSideArrow) {
-  		whichArrow = null;
-  	} else if (this.state.leftSideArrow){
-  		whichArrow = "left";
-  	} else {
-  		whichArrow = "right";
+  	_handleChange(){
+	  	var whichArrow;
+	  	if (this.state.leftSideArrow && this.state.rightSideArrow){
+	  		whichArrow = "both";
+	  	} else if (!this.state.leftSideArrow && !this.state.rightSideArrow) {
+	  		whichArrow = "none";
+	  	} else if (this.state.leftSideArrow){
+	  		whichArrow = "left";
+	  	} else {
+	  		whichArrow = "right";
+	  	}
+	  	this.props.onChange(whichArrow, this.state.centerDashed);
   	}
-  	this.props.onChange(whichArrow, this.state.centerDashed);
-  }
 
 	_toggleView(whichView, whichProperty){
 		if (this.state[whichView]){

--- a/app/components/EditTools.jsx
+++ b/app/components/EditTools.jsx
@@ -17,7 +17,6 @@ export default class EditTools extends BaseComponent {
   constructor(props) {
     super(props);
     this.bindAll('_handleDelete');
-
   }
 
   render() {

--- a/app/components/Graph.jsx
+++ b/app/components/Graph.jsx
@@ -69,7 +69,21 @@ export default class Graph extends BaseComponent {
         selected={this.props.selection && includes(this.props.selection.edgeIds, e.id)}
         clickEdge={this.props.clickEdge}
         moveEdge={this.props.moveEdge} 
-        isLocked={this.props.isLocked} />);
+        isLocked={this.props.isLocked}
+        getArrow={(is_reverse) => this._getArrowDirection(is_reverse, e)}
+        updateArrow={() => this._updateArrowState(e)} />);
+  }
+
+  _getArrowDirection(is_reverse, edge){
+      if (!is_reverse){
+        edge.display.arrow = "left";
+      } else {
+        edge.display.arrow = "right";
+      }
+  }
+
+  _updateArrowState(edge){
+    this.props.graphApi.updateEdge(edge.id, { display: edge.display });
   }
 
   _renderNodes() {

--- a/app/components/Root.jsx
+++ b/app/components/Root.jsx
@@ -161,6 +161,7 @@ export class Root extends Component {
                   <Graph 
                     ref={(c) => { this.graph = c; if (c) { c.root = this; } }}
                     {...this.props}
+                    graphApi={graphApi}
                     graph={annotatedGraph ? annotatedGraph : graph}
                     isEditor={isEditor}
                     isLocked={isLocked}

--- a/app/components/UpdateEdgeForm.jsx
+++ b/app/components/UpdateEdgeForm.jsx
@@ -19,6 +19,7 @@ export default class UpdateEdgeForm extends BaseComponent {
       'esc': () => this.props.deselect()
     };
 
+
     const scales = [
       [null, "Scale"],
       [1, "1x"],
@@ -26,23 +27,12 @@ export default class UpdateEdgeForm extends BaseComponent {
       [2, "2x"],
       [3, "3x"]
     ];
-    
 
     return (
       <div className="editForm updateForm form-inline">
         <HotKeys keyMap={keyMap} handlers={keyHandlers}>
           <div>
             <input 
-              type="checkbox" 
-              ref="arrow" 
-              checked={display.arrow} 
-              onChange={() => this.apply()} /> arrow
-            &nbsp;&nbsp;<input 
-              type="checkbox" 
-              ref="dash" 
-              checked={display.dash} 
-              onChange={() => this.apply()} /> dash
-            &nbsp;&nbsp;<input 
               type="text" 
               className="form-control input-sm"
               placeholder="label" 
@@ -70,21 +60,21 @@ export default class UpdateEdgeForm extends BaseComponent {
               onChange={() => this.apply()} />
           </div>
           <EdgeDropdown
+            ref="edgeDropdown"
             arrow={display.arrow}
-            dash={display.dash}/>
+            dash={display.dash}
+            onChange={(arrow, dash) => this.apply(arrow, dash)}/>
         </HotKeys>
       </div>
     );
   }
 
-  apply() {
-    if (this.props.data) {
+  apply(whichArrow, isDashed) {
       let label = this.refs.label.value;
-      let arrow = this.refs.arrow.checked;
-      let dash = this.refs.dash.checked;
+      let arrow = whichArrow || this.refs.edgeDropdown.props.whichArrow;
+      let dash = isDashed;
       let scale = parseFloat(this.refs.scale.value);
       let url = this.refs.url.value.trim();
       this.props.updateEdge(this.props.data.id, { display: { label, arrow, dash, scale, url } });
-    }
   }
 }

--- a/app/components/UpdateEdgeForm.jsx
+++ b/app/components/UpdateEdgeForm.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import BaseComponent from './BaseComponent';
+import EdgeDropdown from './EdgeDropdown';
 import { HotKeys } from 'react-hotkeys';
 import values from 'lodash/values';
 import sortBy from 'lodash/sortBy'; 
@@ -25,6 +26,7 @@ export default class UpdateEdgeForm extends BaseComponent {
       [2, "2x"],
       [3, "3x"]
     ];
+    
 
     return (
       <div className="editForm updateForm form-inline">
@@ -67,6 +69,9 @@ export default class UpdateEdgeForm extends BaseComponent {
               value={display.url}
               onChange={() => this.apply()} />
           </div>
+          <EdgeDropdown
+            arrow={display.arrow}
+            dash={display.dash}/>
         </HotKeys>
       </div>
     );

--- a/app/components/UpdateEdgeForm.jsx
+++ b/app/components/UpdateEdgeForm.jsx
@@ -10,7 +10,6 @@ export default class UpdateEdgeForm extends BaseComponent {
 
   render() {
     let { display } = this.props.data;
-
     const keyMap = { 
       'esc': 'esc'
     };
@@ -62,7 +61,9 @@ export default class UpdateEdgeForm extends BaseComponent {
           <EdgeDropdown
             ref="edgeDropdown"
             arrow={display.arrow}
-            dash={display.dash}
+             dash={display.dash}
+            edgeId={this.props.data.id}
+            updateEdge={this.props.updateEdge}
             onChange={(arrow, dash) => this.apply(arrow, dash)}/>
         </HotKeys>
       </div>

--- a/app/components/__tests__/Edge-test.jsx
+++ b/app/components/__tests__/Edge-test.jsx
@@ -28,8 +28,9 @@ describe("Edge Component", () => {
   };
 
   it("should render a curve with a control point", () => {
+    let getArrow = jest.genMockFunction();
     let edge = TestUtils.renderIntoDocument(
-      <Edge edge={data} />
+      <Edge edge={data} getArrow={getArrow}/>
     );
     let element = ReactDOM.findDOMNode(edge);
     let curve = element.querySelector(".edge-line");
@@ -38,8 +39,9 @@ describe("Edge Component", () => {
   });
 
   it("should render a label", () => {
+    let getArrow = jest.genMockFunction();
     let edge = TestUtils.renderIntoDocument(
-      <Edge edge={data} />
+      <Edge edge={data} getArrow={getArrow} />
     );
     let element = ReactDOM.findDOMNode(edge);
     let label = element.querySelector("text");
@@ -47,9 +49,16 @@ describe("Edge Component", () => {
     expect(label.textContent).toBe(data.display.label);
   });
 
+  /*not sure of most effective way of testing arrow rendering*/
   it("should render an arrow", () => {
+    let getArrow = jest.genMockFunction().mockImplementation(function () {
+          data["display"]["arrow"] = "left"
+          return data;
+        });
+    let updateArrow = jest.genMockFunction();
+
     let edge = TestUtils.renderIntoDocument(
-      <Edge edge={data} />
+      <Edge edge={data} getArrow={getArrow()} updateArrow={updateArrow} />
     );
     let element = ReactDOM.findDOMNode(edge);
     let curve = element.querySelector(".edge-line");
@@ -59,9 +68,11 @@ describe("Edge Component", () => {
   });
 
   it("should call click callback if clicked", () => {
+    let getArrow = jest.genMockFunction();
+    let updateArrow = jest.genMockFunction();
     let clickEdge = jest.genMockFunction();
     let edge = TestUtils.renderIntoDocument(
-      <Edge edge={data} graphId="someid" clickEdge={clickEdge} />
+      <Edge edge={data} graphId="someid" clickEdge={clickEdge} getArrow={getArrow} updateArrow={updateArrow} />
     );
     let element = ReactDOM.findDOMNode(edge);
     let select = element.querySelector(".edgeSelect");

--- a/app/components/__tests__/EdgeArrowSelector-test.jsx
+++ b/app/components/__tests__/EdgeArrowSelector-test.jsx
@@ -1,0 +1,82 @@
+import React from 'react'; 
+import { shallow } from "enzyme";
+import EdgeArrowSelector from '../EdgeArrowSelector';
+import { newArrowState } from '../../helpers';
+
+
+const element = () => shallow(<EdgeArrowSelector updateEdge={jest.fn()} edgeId="x" arrowSide="left" arrow="left" />);
+
+describe('EdgeArrowSelector', () => {
+   
+  it('has dropDownHolder', () => expect(element().find('.dropdownHolder').length).toEqual(1));
+  it('has selectedEdgeDisplay', () => expect(element().find('.selectedEdgeDisplay').length).toEqual(1));
+  it('sets correct class name for left-left', () =>{
+    let e = shallow(<EdgeArrowSelector updateEdge={jest.fn()} edgeId="x" arrowSide="left" arrow="left" />);
+    expect(e.find('.svgDropdownLeftArrow').length).toEqual(1);
+  });
+  it('sets correct class name for left-right', () =>{
+    let e = shallow(<EdgeArrowSelector updateEdge={jest.fn()} edgeId="x" arrowSide="left" arrow="right" />);
+    expect(e.find('.svgDropdownLeftArrow').length).toEqual(0);
+  });
+  it('sets correct class name for right-right', () =>{
+    let e = shallow(<EdgeArrowSelector updateEdge={jest.fn()} edgeId="x" arrowSide="right" arrow="right" />);
+    expect(e.find('.svgDropdownRightArrow').length).toEqual(1);
+  });
+  it('sets correct class name for right-left', () =>{
+    let e = shallow(<EdgeArrowSelector updateEdge={jest.fn()} edgeId="x" arrowSide="right" arrow="left" />);
+    expect(e.find('.svgDropdownRightArrow').length).toEqual(0);
+  });
+  it('sets correct class name for right-both', () =>{
+    let e = shallow(<EdgeArrowSelector updateEdge={jest.fn()} edgeId="x" arrowSide="right" arrow="both" />);
+    expect(e.find('.svgDropdownRightArrow').length).toEqual(1);
+  });
+  it('sets correct class name for left-both', () =>{
+    let e = shallow(<EdgeArrowSelector updateEdge={jest.fn()} edgeId="x" arrowSide="left" arrow="both" />);
+    expect(e.find('.svgDropdownLeftArrow').length).toEqual(1);
+  });
+
+  it('updates state and re-renders when clicked on', () => {
+    let e = element();
+    expect(e.state().isOpen).toBe(false);
+    expect(e.find('.edgeDropdownOptions').length).toEqual(0);
+    e.find('.selectedEdgeDisplay').simulate('click');
+    expect(e.state().isOpen).toBe(true);
+    expect(e.find('.edgeDropdownOptions').length).toEqual(1);
+  });
+
+  it('updates Edge with new arrow setting', () => {
+    let updateEdgeMock = jest.fn();
+    let e = shallow(<EdgeArrowSelector updateEdge={updateEdgeMock} edgeId="x" arrowSide="left" arrow="left" />);
+    e.find('.selectedEdgeDisplay').simulate('click');
+    e.find('.svgDropdownLeftNoArrow').simulate('click');
+    expect(e.state().isOpen).toBe(false);
+    expect(updateEdgeMock.mock.calls.length).toEqual(1);
+    expect(updateEdgeMock.mock.calls[0]).toEqual(['x', {display: {arrow: false} } ]);
+  });
+
+});
+
+
+describe('newArrowState()', ()=>{
+     
+  it('when current state is left', ()=> {
+    expect(newArrowState('left', 'left', false)).toEqual(false);
+    expect(newArrowState('left', 'left', true)).toEqual('left');
+    expect(newArrowState('left', 'right', false)).toEqual('left');
+    expect(newArrowState('left', 'right', true)).toEqual('both');
+  });
+  it('when current state is right', ()=> {
+    expect(newArrowState('right', 'left', false)).toEqual('right');
+    expect(newArrowState('right', 'left', true)).toEqual('both');
+    expect(newArrowState('right', 'right', false)).toEqual(false);
+    expect(newArrowState('right', 'right', true)).toEqual('right');
+  });
+  it('when current state is both', ()=> {
+    expect(newArrowState('both', 'left', false)).toEqual('right');
+    expect(newArrowState('both', 'left', true)).toEqual('both');
+    expect(newArrowState('both', 'right', false)).toEqual('left');
+    expect(newArrowState('both', 'right', true)).toEqual('both');
+  });
+
+});
+

--- a/app/components/__tests__/EdgeDashSelector-test.jsx
+++ b/app/components/__tests__/EdgeDashSelector-test.jsx
@@ -1,0 +1,50 @@
+import React from 'react'; 
+import { shallow } from "enzyme";
+import EdgeDashSelector from '../EdgeDashSelector';
+
+describe('EdgeDashSelector', () => {
+  
+  it('sets svgDropdownDashed if dashed', () => {
+    let wrapper = shallow(<EdgeDashSelector isDashed={true} updateEdge={jest.fn()} edgeId="x"/>);
+    expect(wrapper.find('.svgDropdownDashed').length).toEqual(1);
+  });
+  
+  it('does not set svgDropdownDashed if not dashed', () => {
+    let wrapper = shallow(<EdgeDashSelector isDashed={false} updateEdge={jest.fn()} edgeId="x "/>);
+    expect(wrapper.find('.svgDropdownDashed').length).toEqual(0);
+  });
+
+  describe('click on menu', () => {
+    let wrapper = shallow(<EdgeDashSelector isDashed={false} updateEdge={jest.fn()} edgeId="x "/>);
+    it('updates state and re-renders', ()=>{
+      expect(wrapper.state().isOpen).toBe(false);
+      expect(wrapper.find('.edgeDropdownOptions').length).toEqual(0);
+      wrapper.find('.selectedEdgeDisplay').childAt(0).simulate('click');
+      expect(wrapper.state().isOpen).toBe(true);
+      expect(wrapper.find('.edgeDropdownOptions').length).toEqual(1);
+    });
+  });
+
+  describe('select an option', ()=>{
+    it('calls updateEdge with correct arg - undashed', () =>{
+      let updateEdgeMock = jest.fn();
+      let wrapper = shallow(<EdgeDashSelector isDashed={false} updateEdge={updateEdgeMock} edgeId="x"/>);
+      wrapper.find('.selectedEdgeDisplay').childAt(0).simulate('click');
+      wrapper.find('.svgDropdownUndashed').simulate('click');
+      expect(updateEdgeMock.mock.calls.length).toEqual(1);
+      expect(updateEdgeMock.mock.calls[0]).toEqual(['x', {display: {dash: false} } ]);
+      expect(wrapper.state().isOpen).toBe(false);
+      
+    });
+    it('calls updateEdge with correct arg - dashed', () =>{
+      let updateEdgeMock = jest.fn();
+      let wrapper = shallow(<EdgeDashSelector isDashed={false} updateEdge={updateEdgeMock} edgeId="x" />);
+      wrapper.find('.selectedEdgeDisplay').childAt(0).simulate('click');
+      wrapper.find('.svgDropdownDashed').simulate('click');
+      expect(updateEdgeMock.mock.calls.length).toEqual(1);
+      expect(updateEdgeMock.mock.calls[0]).toEqual(['x', {display: {dash: true}} ]);
+      expect(wrapper.state().isOpen).toBe(false);
+    });
+  });
+  
+});

--- a/app/components/__tests__/EdgeDropdown-test.jsx
+++ b/app/components/__tests__/EdgeDropdown-test.jsx
@@ -1,0 +1,104 @@
+jest.disableAutomock();
+
+import React from "react";
+import ReactDOM from 'react-dom';
+import { shallow } from "enzyme";
+import { mount } from "enzyme";
+
+import EdgeDropdown from "../EdgeDropdown";
+
+describe("EdgeDropdown", () => {
+  let wrapper;
+  let onChange;
+
+  beforeEach(() => {
+    onChange = jest.genMockFunction();
+    wrapper = mount(
+      <EdgeDropdown
+        dash={true}
+        arrow="left"
+        onChange={onChange} />
+    );
+  });
+
+  it("it shows a div for both potential arrowheads and each should contain an svg", () => {
+    let arrows = wrapper.find(".dropdownHolder.arrowHead").children();
+    expect(arrows.length).toBe(2);
+    let allArrows = true;
+    arrows.forEach(function(a){
+      if (a.find("svg").length != 1){
+        allArrows = false;
+      }
+    })
+    
+    expect(allArrows).toBe(true);
+  });
+
+  it("it shows one div for the dash/undash dropdown and it should contain an svg", () => {
+    let central = wrapper.find(".dropdownHolder.strokeMain").children();
+    expect(central.length).toBe(1);
+    expect(central.find("svg").length).toBe(1);
+  });
+
+  it("it should not show dropdown lists prior to clicking", () => {
+    let dropdowns = wrapper.find(".svgDropdown.edgeDropdownOptions");
+    expect(dropdowns.length).toBe(0);
+  });
+
+  it("shows/hides a dropdown when clicked and the state reflects that", () => {
+    expect(wrapper.state()["leftSideOpen"]).toBe(false);
+    expect(wrapper.state()["rightSideOpen"]).toBe(false);
+    expect(wrapper.state()["centerOpen"]).toBe(false);
+
+    let dropdownButtons = wrapper.find(".selectedEdgeDisplay");
+    dropdownButtons.forEach(function(d){
+      d.simulate("click");
+    });
+    wrapper.update();
+
+    let dropdowns = wrapper.find(".svgDropdown.edgeDropdownOptions");
+    expect(dropdowns.length).toBe(3);
+
+    expect(wrapper.state()["leftSideOpen"]).toBe(true);
+    expect(wrapper.state()["rightSideOpen"]).toBe(true);
+    expect(wrapper.state()["centerOpen"]).toBe(true);
+
+    dropdowns.forEach(function(dr){
+      dr.find("li").at(0).simulate("click");
+    });
+
+    expect(wrapper.state()["leftSideOpen"]).toBe(false);
+    expect(wrapper.state()["rightSideOpen"]).toBe(false);
+    expect(wrapper.state()["centerOpen"]).toBe(false);
+
+    wrapper.update();
+
+    let dropdownsUpdated = wrapper.find(".svgDropdown.edgeDropdownOptions");
+
+    expect(dropdownsUpdated.length).toBe(0);
+
+  });
+  
+
+  it("updates the state to match the clicked-on value from the drop-down list", () => {
+    expect(wrapper.state()["leftSideArrow"]).toBe(true);
+    expect(wrapper.state()["rightSideArrow"]).toBe(false);
+    expect(wrapper.state()["centerDashed"]).toBe(true);
+
+    let dropdownButtons = wrapper.find(".selectedEdgeDisplay");
+    dropdownButtons.forEach(function(d){
+      d.simulate("click");
+    });
+    wrapper.update();
+
+    let dropdowns = wrapper.find(".svgDropdown.edgeDropdownOptions");
+    dropdowns.at(0).find("li.svgDropdownLeftNoArrow").simulate("click");
+    dropdowns.at(1).find("li.svgDropdownUndashed").simulate("click");
+    dropdowns.at(2).find("li.svgDropdownRightArrow").simulate("click");
+
+    expect(wrapper.state()["leftSideArrow"]).toBe(false);
+    expect(wrapper.state()["rightSideArrow"]).toBe(true);
+    expect(wrapper.state()["centerDashed"]).toBe(false);
+  })
+
+});

--- a/app/components/__tests__/EdgeDropdown-test.jsx
+++ b/app/components/__tests__/EdgeDropdown-test.jsx
@@ -1,104 +1,43 @@
-jest.disableAutomock();
-
 import React from "react";
 import ReactDOM from 'react-dom';
 import { shallow } from "enzyme";
-import { mount } from "enzyme";
-
 import EdgeDropdown from "../EdgeDropdown";
+import { legacyArrowConverter } from '../../helpers';
+import EdgeArrowSelector from '../EdgeArrowSelector';
+import EdgeDashSelector from '../EdgeDashSelector';
 
 describe("EdgeDropdown", () => {
-  let wrapper;
-  let onChange;
+  
+  describe('layout', () => {
+    let wrapper = shallow(<EdgeDropdown 
+                          updateEdge={jest.fn()}
+                          edgeId="123"
+                          dash={false}
+                          arrow="left" />);
 
-  beforeEach(() => {
-    onChange = jest.genMockFunction();
-    wrapper = mount(
-      <EdgeDropdown
-        dash={true}
-        arrow="left"
-        onChange={onChange} />
-    );
+    it('has EdgeDashSelector', () => expect(wrapper.find(EdgeDashSelector).length).toEqual(1));
+    it('has two EdgeArrowSelector', () => expect(wrapper.find(EdgeArrowSelector).length).toEqual(2));
   });
 
-  it("it shows a div for both potential arrowheads and each should contain an svg", () => {
-    let arrows = wrapper.find(".dropdownHolder.arrowHead").children();
-    expect(arrows.length).toBe(2);
-    let allArrows = true;
-    arrows.forEach(function(a){
-      if (a.find("svg").length != 1){
-        allArrows = false;
-      }
-    })
+  describe('legacyArrowConverter', () => {
     
-    expect(allArrows).toBe(true);
-  });
-
-  it("it shows one div for the dash/undash dropdown and it should contain an svg", () => {
-    let central = wrapper.find(".dropdownHolder.strokeMain").children();
-    expect(central.length).toBe(1);
-    expect(central.find("svg").length).toBe(1);
-  });
-
-  it("it should not show dropdown lists prior to clicking", () => {
-    let dropdowns = wrapper.find(".svgDropdown.edgeDropdownOptions");
-    expect(dropdowns.length).toBe(0);
-  });
-
-  it("shows/hides a dropdown when clicked and the state reflects that", () => {
-    expect(wrapper.state()["leftSideOpen"]).toBe(false);
-    expect(wrapper.state()["rightSideOpen"]).toBe(false);
-    expect(wrapper.state()["centerOpen"]).toBe(false);
-
-    let dropdownButtons = wrapper.find(".selectedEdgeDisplay");
-    dropdownButtons.forEach(function(d){
-      d.simulate("click");
+    it('returns input if given left/right/both', () => {
+      expect(legacyArrowConverter('left')).toEqual('left');
+      expect(legacyArrowConverter('right')).toEqual('right');
+      expect(legacyArrowConverter('both')).toEqual('both');
     });
-    wrapper.update();
-
-    let dropdowns = wrapper.find(".svgDropdown.edgeDropdownOptions");
-    expect(dropdowns.length).toBe(3);
-
-    expect(wrapper.state()["leftSideOpen"]).toBe(true);
-    expect(wrapper.state()["rightSideOpen"]).toBe(true);
-    expect(wrapper.state()["centerOpen"]).toBe(true);
-
-    dropdowns.forEach(function(dr){
-      dr.find("li").at(0).simulate("click");
+    
+    it('returns left if input is truthy', () => {
+      expect(legacyArrowConverter(true)).toEqual('left');
+      expect(legacyArrowConverter('yes')).toEqual('left');
     });
 
-    expect(wrapper.state()["leftSideOpen"]).toBe(false);
-    expect(wrapper.state()["rightSideOpen"]).toBe(false);
-    expect(wrapper.state()["centerOpen"]).toBe(false);
-
-    wrapper.update();
-
-    let dropdownsUpdated = wrapper.find(".svgDropdown.edgeDropdownOptions");
-
-    expect(dropdownsUpdated.length).toBe(0);
-
+    it('returns false if input is falsy', () => {
+      expect(legacyArrowConverter(false)).toEqual(false);
+      expect(legacyArrowConverter(null)).toEqual(false);
+      expect(legacyArrowConverter(undefined)).toEqual(false);
+    });
+    
   });
   
-
-  it("updates the state to match the clicked-on value from the drop-down list", () => {
-    expect(wrapper.state()["leftSideArrow"]).toBe(true);
-    expect(wrapper.state()["rightSideArrow"]).toBe(false);
-    expect(wrapper.state()["centerDashed"]).toBe(true);
-
-    let dropdownButtons = wrapper.find(".selectedEdgeDisplay");
-    dropdownButtons.forEach(function(d){
-      d.simulate("click");
-    });
-    wrapper.update();
-
-    let dropdowns = wrapper.find(".svgDropdown.edgeDropdownOptions");
-    dropdowns.at(0).find("li.svgDropdownLeftNoArrow").simulate("click");
-    dropdowns.at(1).find("li.svgDropdownUndashed").simulate("click");
-    dropdowns.at(2).find("li.svgDropdownRightArrow").simulate("click");
-
-    expect(wrapper.state()["leftSideArrow"]).toBe(false);
-    expect(wrapper.state()["rightSideArrow"]).toBe(true);
-    expect(wrapper.state()["centerDashed"]).toBe(false);
-  })
-
 });

--- a/app/components/__tests__/EditTools-test.jsx
+++ b/app/components/__tests__/EditTools-test.jsx
@@ -1,0 +1,170 @@
+import React from 'react'; 
+import { shallow } from 'enzyme';
+import EditTools from '../EditTools';
+import EditButtons from '../EditButtons';
+import LayoutButtons from '../LayoutButtons';
+import UndoButtons from '../UndoButtons';
+import AddEdgeForm from '../AddEdgeForm';
+import AddCaptionForm from '../AddCaptionForm';
+import AddConnectedNodesForm from '../AddConnectedNodesForm';
+import DeleteSelectedButton from '../DeleteSelectedButton';
+import UpdateNodeForm from '../UpdateNodeForm';
+import UpdateEdgeForm from '../UpdateEdgeForm';
+import UpdateCaptionForm from '../UpdateCaptionForm';
+import HelpScreen from '../HelpScreen';
+
+const GraphApi = () => ({
+  getGraph: jest.fn(),
+  zoomIn: jest.fn(),
+  zoomOut: jest.fn(),
+  resetZoom: jest.fn(),
+  prune: jest.fn(),
+  circleLayout: jest.fn(),
+  addNode: jest.fn(),
+  addEdge: jest.fn(),
+  addCaption: jest.fn(),
+  updateNode: jest.fn(),
+  updateEdge: jest.fn(),
+  updateCaption: jest.fn(),
+  deselectAll: jest.fn(),
+  deleteAll: jest.fn(),
+  addSurroundingNodes: jest.fn()
+});
+
+// helpers //
+const hasComponent = (root, c) => expect(root.find(c).length).toEqual(1);
+const hasNoComponent = (root, c) => expect(root.find(c).length).toEqual(0);
+
+describe('Edit Tools Component', () => {
+  
+  describe('Always present components', () => {
+    let graphApi = GraphApi();
+    let graph = {nodes: []};
+    let editTools = shallow(
+      <EditTools 
+         graphApi={graphApi} 
+         graph={graph}
+         nodeResults={[]}
+         /> );
+    
+    it('contains editTools div', () => hasComponent(editTools, '#editTools'));
+    it('contains buttons div', () => expect(editTools.find('#buttons').length).toEqual(1));
+    it('contains EditButtons', () => expect(editTools.containsMatchingElement(EditTools)).toBe(true));
+    it('contains LayoutButtons', () => expect(editTools.find(LayoutButtons).length).toEqual(1));
+    it('contains UndoButtons', () => expect(editTools.find(UndoButtons).length).toEqual(1));
+  });
+  
+  describe('Conditionally displayed components', () => {
+    let graphApi = GraphApi();
+    let graph = {nodes: []};
+
+    describe('currentForm', () => {
+
+      it('displays UpdateCaptionForm', ()=>{
+        let editTools = shallow(<EditTools
+                                graphApi={graphApi} 
+                                graph={graph}
+                                nodeResults={[]}
+                                currentForm='UpdateCaptionForm' />);
+        expect(editTools.find(UpdateCaptionForm).length).toEqual(1);
+        expect(editTools.find(AddCaptionForm).length).toEqual(0);
+      });
+
+      it('displays AddCaptionForm', ()=>{
+        let editTools = shallow(<EditTools
+                                graphApi={graphApi} 
+                                graph={graph}
+                                nodeResults={[]}/>);
+        expect(editTools.find(UpdateCaptionForm).length).toEqual(0);
+        expect(editTools.find(AddCaptionForm).length).toEqual(1);
+      });
+    });
+
+    describe('helpButton', () => {
+
+      it('displays helpButton if hideHelp is falsy', ()=>{
+        let editTools = shallow(<EditTools
+                                graphApi={graphApi} 
+                                graph={graph}
+                                nodeResults={[]}
+                                hideHelp={false}
+                                />);
+        hasComponent(editTools, '#helpButton');
+      });
+
+      it('does not display helpButton if hideHelp is truthy', ()=>{
+        let editTools = shallow(<EditTools
+                                graphApi={graphApi} 
+                                graph={graph}
+                                nodeResults={[]}
+                                hideHelp={true}
+                                />);
+        hasNoComponent(editTools, '#helpButton');
+      });
+    });
+
+    describe('addForm', () => {
+
+      it('displays addEdgeForm if addForm is AddEdgeForm', () =>{
+        let editTools = shallow(<EditTools
+                                graphApi={graphApi} 
+                                graph={graph}
+                                nodeResults={[]}
+                                addForm='AddEdgeForm'
+                                />);
+        hasComponent(editTools, AddEdgeForm);
+        hasNoComponent(editTools, DeleteSelectedButton);
+      });
+
+      it('does not display addEdgeForm', () =>{
+        let editTools = shallow(<EditTools
+                                graphApi={graphApi} 
+                                graph={graph}
+                                nodeResults={[]}
+                                addForm='' />);
+        hasNoComponent(editTools, AddEdgeForm);
+      });
+    });
+
+    describe('currentForm', () => {
+      
+      it('displays UpdateEdgeForm', () => {
+        let editTools = shallow(<EditTools
+                                graphApi={graphApi} 
+                                graph={graph}
+                                nodeResults={[]}
+                                currentForm='UpdateEdgeForm' />);
+
+        hasComponent(editTools, UpdateEdgeForm);
+        hasComponent(editTools, DeleteSelectedButton);
+      });
+      
+      it('displays UpdateNodeForm', () => {
+        let editTools = shallow(<EditTools
+                                graphApi={graphApi} 
+                                graph={graph}
+                                nodeResults={[]}
+                                currentForm='UpdateNodeForm' />);
+
+        hasComponent(editTools, UpdateNodeForm);
+        hasComponent(editTools, DeleteSelectedButton);
+        hasNoComponent(editTools, AddConnectedNodesForm);
+      });
+
+      it('displays AddConnectedNodesForm', () => {
+        let source = { getConnectedNodes: jest.fn() };
+        let editTools = shallow(<EditTools
+                                graphApi={graphApi} 
+                                graph={graph}
+                                nodeResults={[]}
+                                currentForm='UpdateNodeForm' 
+                                source={source}
+                                />);
+        hasComponent(editTools, AddConnectedNodesForm);
+      });
+
+    });
+
+  });
+
+});

--- a/app/components/__tests__/UpdateEdgeForm-test.jsx
+++ b/app/components/__tests__/UpdateEdgeForm-test.jsx
@@ -4,6 +4,8 @@ import React from "react";
 import { mount } from "enzyme";
 
 import UpdateEdgeForm from "../UpdateEdgeForm";
+import EdgeDropdown from "../EdgeDropdown";
+
 
 describe("UpdateEdgeForm", () => {
   let wrapper;
@@ -16,7 +18,7 @@ describe("UpdateEdgeForm", () => {
       label: "Edge",
       url: "http://example.com/node",
       scale: 3,
-      arrow: true,
+      arrow: "right",
       dash: false,
       status: "highlighted"
     }
@@ -33,22 +35,18 @@ describe("UpdateEdgeForm", () => {
   });
 
   describe("rendering", () => {
-    it("shows arrow input", () => {
-      let input = wrapper.ref("arrow");
-      expect(input.length).toBe(1);
-      expect(input.props().checked).toBe(data.display.arrow);
-    });
-
-    it("shows dash input", () => {
-      let input = wrapper.ref("dash");
-      expect(input.length).toBe(1);
-      expect(input.props().checked).toBe(data.display.dash);
-    });
 
     it("shows label input", () => {
       let input = wrapper.ref("label");
       expect(input.length).toBe(1);
       expect(input.props().value).toBe(data.display.label);
+    });
+
+    it("shows a dropdown menu that reflects the selected edge's appearance", () => {
+      let edgeDropdown = wrapper.ref("edgeDropdown");
+      expect(edgeDropdown.length).toBe(1);
+      expect(edgeDropdown.props().arrow).toBe(data.display.arrow);
+      expect(edgeDropdown.props().dash).toBe(data.display.dash);
     });
 
     it("shows scale dropdown with selected option", () => {
@@ -69,23 +67,6 @@ describe("UpdateEdgeForm", () => {
   });
 
   describe("behavior", () => {
-    it("passes updated arrow to updateEdge", () => {
-      let input = wrapper.ref("arrow");
-      input.get(0).checked = !data.display.arrow;
-      input.props().onChange();
-
-      expect(updateEdge.mock.calls.length).toBe(1);
-      expect(updateEdge.mock.calls[0][1].display.arrow).toBe(!data.display.arrow);
-    });
-
-    it("passes updated dash to updateEdge", () => {
-      let input = wrapper.ref("dash");
-      input.get(0).checked = !data.display.dash;
-      input.props().onChange();
-
-      expect(updateEdge.mock.calls.length).toBe(1);
-      expect(updateEdge.mock.calls[0][1].display.dash).toBe(!data.display.dash);
-    });
 
     it("passes updated scale to updateEdge", () => {
       let select = wrapper.ref("scale");
@@ -105,5 +86,16 @@ describe("UpdateEdgeForm", () => {
       expect(updateEdge.mock.calls.length).toBe(1);
       expect(updateEdge.mock.calls[0][1].display.url).toBe(newUrl.trim());
     });
+
+    it("passes updated edge appearance to updateEdge", () => {
+      let edgeDropdown = wrapper.ref("edgeDropdown");
+      let dropdownOnChange = edgeDropdown.props().onChange;
+      dropdownOnChange("left", true);
+
+      expect(updateEdge.mock.calls.length).toBe(1);
+      expect(updateEdge.mock.calls[0][1].display.arrow).toBe("left");
+      expect(updateEdge.mock.calls[0][1].display.dash).toBe(true);
+    });
+
   });
 });

--- a/app/helpers.js
+++ b/app/helpers.js
@@ -1,3 +1,5 @@
+import includes from 'lodash/includes';
+
 /**
  * Calculates New Position for Draggable Components
  * @param {object} draggableData - data from react-draggable callback
@@ -12,4 +14,58 @@ export const calculateDeltas = (draggableData, startPosition, startDrag, actualZ
   let x = deltaX + startPosition.x;
   let y = deltaY + startPosition.y;
   return { x, y };
+};
+
+/**
+ * Previously arrow could only go in one direction. This converts a true value into 'left'
+ * @param {string|boolean|null} arrow
+ */
+export const legacyArrowConverter = arrow => {
+  if (includes(['left', 'right', 'both'], arrow)) {
+    return arrow;
+  } else {
+    return arrow ? 'left' : false;
+  }
+};
+
+// Determines new state of arrow: 
+// input: string, string, boolean
+// output: string | false;
+// used by EdgeArrowSelector
+export const newArrowState = (oldArrowState, arrowSide, showArrow) => {
+  const rightSide = (arrowSide === 'right');
+  const leftSide = (arrowSide === 'left');
+  
+  
+  if(oldArrowState === 'left') {
+    if (rightSide && showArrow) {
+      return 'both';
+    }
+    if (leftSide && !showArrow) {
+      return false;
+    }
+  } else if (oldArrowState === 'right') {
+    if (leftSide && showArrow) {
+      return 'both';
+    }
+    if (rightSide && !showArrow) {
+      return false;
+    }
+  } else if (oldArrowState === 'both') {
+    if (leftSide && !showArrow) {
+      return 'right';
+    }
+    if (rightSide && !showArrow) {
+      return 'left';
+    }
+  } else if (oldArrowState === false) {
+    if (leftSide && showArrow) {
+      return 'left';
+    }
+    if (rightSide && showArrow) {
+      return 'right';
+    }
+  }
+  // default case
+  return oldArrowState;
 };

--- a/app/models/__tests__/Graph-test.js
+++ b/app/models/__tests__/Graph-test.js
@@ -254,4 +254,22 @@ describe("Graph", () => {
       expect(scales).toBeArrayOfNumbers;
     });
   });
+
+  describe('updateEdge', ()=> {
+    
+    it('changes label', () => {
+      let new_graph = Graph.updateEdge(basicGraph, 1, {display: { label: "This is a better label for edge 1" }});
+      expect(new_graph.edges['1'].display.label).toEqual("This is a better label for edge 1" );
+    });
+
+    it('can merge nested proprieties', () => {
+      let new_graph = Graph.updateEdge(basicGraph, 1, {display: { label: "This is a better label for edge 1" }});
+      let new_graph2 = Graph.updateEdge(new_graph, 1, {display: { dash: true } });
+      expect(new_graph2.edges['1'].display.label).toEqual("This is a better label for edge 1" );
+      expect(new_graph2.edges['1'].display.dash).toEqual(true);
+    });
+
+  });
+
+
 });

--- a/app/styles/oligrapher.editor.css
+++ b/app/styles/oligrapher.editor.css
@@ -100,6 +100,7 @@ button#toggleEditTools {
   top: 15px;
   right: 15px;
   margin: 0 auto;
+  text-align: right;
 }
 
 .editForm h3 {
@@ -230,7 +231,7 @@ button#toggleEditTools {
 }
 
 .strokeMain{
-  width:80%;
+  width:50%;
   margin-right: 2%;
   margin-left: 2%;
 }
@@ -238,9 +239,10 @@ button#toggleEditTools {
 .arrowHead{
   width:8%;
 }
+
 .strokeDropdowns{
-  display: block;
-  position: absolute;
+  display: inline-block;
+  width:300px;
 }
 
 .dropdownHolder{
@@ -249,7 +251,7 @@ button#toggleEditTools {
 
 .svgDropdown li, .svgDropdown div{
   width: 100%;
-  height: 20px; 
+  height: 29px; 
   list-style: none;
 }
 
@@ -294,4 +296,10 @@ button#toggleEditTools {
 .edgeDropdownOptions{
   position: absolute;
   width: inherit;
+  margin-top: 80px;
+}
+
+.oligrapherEdgeWidthDropdown{
+  width: auto;
+  text-align: right;
 }

--- a/app/styles/oligrapher.editor.css
+++ b/app/styles/oligrapher.editor.css
@@ -231,18 +231,19 @@ button#toggleEditTools {
 }
 
 .strokeMain{
-  width:50%;
+  width:25%;
   margin-right: 2%;
   margin-left: 2%;
 }
 
 .arrowHead{
-  width:8%;
+  width:20%;
 }
 
 .strokeDropdowns{
   display: inline-block;
-  width:300px;
+  width:200px;
+  margin-right: 120px;
 }
 
 .dropdownHolder{

--- a/app/styles/oligrapher.editor.css
+++ b/app/styles/oligrapher.editor.css
@@ -243,7 +243,7 @@ button#toggleEditTools {
 .strokeDropdowns{
   display: inline-block;
   width:200px;
-  margin-right: 120px;
+  margin-right: 145px;
 }
 
 .dropdownHolder{
@@ -296,7 +296,7 @@ button#toggleEditTools {
 
 .edgeDropdownOptions{
   position: absolute;
-  width: inherit;
+  width: 20%;
   margin-top: 80px;
 }
 

--- a/app/styles/oligrapher.editor.css
+++ b/app/styles/oligrapher.editor.css
@@ -213,3 +213,85 @@ button#toggleEditTools {
 #edgeUrlInput {
   width: 337px;
 }
+
+.svgDropdown{
+  height: auto;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075); 
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, .075); 
+  -webkit-transition: border-color ease-in-out .15s, -webkit-box-shadow ease-in-out .15s; 
+  -o-transition: border-color ease-in-out .15s, box-shadow ease-in-out .15s;
+  list-style-type: none;
+  padding:0px;
+  margin:0px;
+  top:0px;
+}
+
+.strokeMain{
+  width:80%;
+  margin-right: 2%;
+  margin-left: 2%;
+}
+
+.arrowHead{
+  width:8%;
+}
+.strokeDropdowns{
+  display: block;
+  position: absolute;
+}
+
+.dropdownHolder{
+  display: inline-block;
+}
+
+.svgDropdown li, .svgDropdown div{
+  width: 100%;
+  height: 20px; 
+  list-style: none;
+}
+
+.svgDropdown li:not(:last-child){
+  border-bottom: 1px solid #ccc; 
+}
+
+/*displays oddly in chrome if there is no border on last element for some reason*/
+.svgDropdown li:last-child, .svgDropdown div{
+  border-bottom: 1px solid rgba(0,0,0,0);
+}
+
+.svgDropdown li svg, .svgDropdown div svg{
+  width: 100%;
+  height: 100%;
+  shape-rendering: crispEdges;
+  cursor: pointer;
+}
+
+.svgDropdown li:hover{
+  background-color: yellow;
+}
+
+.svgDropdown li svg line, .svgDropdown div svg line{
+  stroke:#aaa;
+  stroke-width:1px;
+  stroke-linecap: butt;
+}
+
+.svgDropdownDashed svg line{
+  stroke-dasharray: 5, 3;
+}
+
+.svgDropdownLeftArrow svg line{
+  marker-end: url(#marker1);
+}
+
+.svgDropdownRightArrow svg line{
+  marker-start: url(#marker2);
+}
+
+.edgeDropdownOptions{
+  position: absolute;
+  width: inherit;
+}


### PR DESCRIPTION
This branch changes the input method for changing the appearance of edges (i.e. changing if the edge has an arrowhead or if it is dashed) from a series of checkboxes to a dropdown menu system.

Data can be entered using the existing JSON format (e.g., `arrow: true` vs `arrow: null`), but it is immediately overwritten with one of the following values: "left", "right", "both" or "none" to reflect which side of the edge the arrowhead is on.
