### PR TITLE
Fix the annotation visibility toggle 

### DIFF
--- a/app/models/__tests__/Annotation-test.js
+++ b/app/models/__tests__/Annotation-test.js
@@ -1,0 +1,29 @@
+jest.unmock('../Annotation');
+
+import Annotation from '../Annotation';
+
+describe('Annotation', ()=>{
+  
+  describe('defaults', ()=>{
+    it('returns an object', ()=> expect(typeof Annotation.defaults()).toEqual('object') );
+  });
+  
+  describe('setDefaults', ()=> {
+
+    it('provides defaults when given an empty object', () =>{
+      const a = Annotation.setDefaults({});
+      expect(a.header).toEqual("Untitled Annotation");
+      expect(a.text).toEqual('');
+      expect(a.nodeIds).toEqual([]);
+      expect(a.captionIds).toEqual([]);
+      expect(a.edgeIds).toEqual([]);
+      expect(a.id).toBeDefined();
+    });
+    
+    it('merges defaults when provided an annotation object', ()=>{
+      expect(Annotation.setDefaults({header: "new header"}).header).toEqual('new header');
+      expect(Annotation.setDefaults({header: "new header"}).nodeIds).toEqual([]);
+    });
+  });
+  
+});

--- a/app/reducers/__tests__/annotations-test.js
+++ b/app/reducers/__tests__/annotations-test.js
@@ -1,0 +1,53 @@
+jest.unmock("../annotations");
+jest.unmock('../../actions');
+jest.unmock("../../models/Annotation");
+jest.unmock("lodash");
+
+import reducer from "../annotations";
+import {loadAnnotations, toggleAnnotations} from '../../actions';
+
+describe("annotations reducer", ()=>{
+  
+  it("should return initial state", () => {
+    expect(reducer(undefined, {})).toEqual({list:[], visible: true, currentIndex: 0});
+  });
+  
+  it('stores the annotations in state.list when LOAD_ANNOTATIONS is triggered', () =>{
+    let annotations = [{
+      id: '123',
+      header: "header",
+      text: "some text here",
+      nodeIds: ["x1","33180","15957"],
+      edgeIds: [],
+      captionIds: []
+    }];
+    
+    
+    expect(reducer(undefined, loadAnnotations(annotations))).toEqual({
+      list: [{
+        id: '123',
+        header: "header",
+        text: "some text here",
+        nodeIds: ["x1","33180","15957"],
+        edgeIds: [],
+        captionIds: []
+      }],
+      visible: true,
+      currentIndex: 0
+    });
+
+  });
+  
+  describe('TOGGLE_ANNOTATIONS', ()=>{
+
+    it('flips the visible state from false to true', ()=>{
+      expect( reducer({visible: false}, toggleAnnotations({})) ).toEqual({visible: true});
+    });
+   
+    it('flips the visible state from true to false', ()=>{
+      expect( reducer({visible: true}, toggleAnnotations({})) ).toEqual({visible: false});
+    });
+
+  });
+
+});

--- a/app/reducers/annotations.js
+++ b/app/reducers/annotations.js
@@ -59,7 +59,7 @@ export default function annotations(state = initState, action) {
     });
 
   case TOGGLE_ANNOTATIONS:
-    let visible = typeof action.value == "undefined" ? !state.visible : action.value;
+    let visible = !state.visible;
     return merge({}, state, { visible });
 
   case SWAP_NODE_HIGHLIGHT:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prod-build": "NODE_ENV=production webpack --display-modules --config webpack.prod.config.js --output-filename=oligrapher.js",
     "min-build": "NODE_ENV=production webpack -p --optimize-dedupe --display-modules --config webpack.prod.config.js --output-filename=oligrapher.min.js",
     "build-all": "npm run prod-build && npm run min-build",
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
TOGGLE_ANNOTATIONS acts in a much simpler way: it now simply reverses the
state of annotations.visible. The button in the top right hand corner
works correctly.

fixes #37
- Add some tests for the Annotation Reducer
- Add tests for models/Annotation
- Add test:watch npm script
