### PR TITLE
settings and update node/edge forms can be shown simultaneously.

### DIFF
--- a/app/components/Editor.jsx
+++ b/app/components/Editor.jsx
@@ -103,10 +103,6 @@ export default class Editor extends BaseComponent {
     let formData = null;
     let addForm = this.props.addForm;
 
-    if (this.props.showSettings) {
-      return { currentForm, formData, addForm: null };
-    }
-
     let { nodeIds, edgeIds, captionIds } = this.props.selection;
     let graph = this.props.graph;
     let nodes = pick(graph.nodes, nodeIds);

--- a/app/components/Root.jsx
+++ b/app/components/Root.jsx
@@ -193,7 +193,7 @@ class Root extends Component {
                     <HelpButton toggleHelpScreen={() => dispatch(toggleHelpScreen())} /> }
                 </div>
 
-                { showSettings && hasSettings && <GraphSettingsForm settings={graphSettings} updateSettings={updateSettings} /> }
+                { isEditor && showSettings && hasSettings && showEditTools && <GraphSettingsForm settings={graphSettings} updateSettings={updateSettings} /> }
               </div>
             </div>
             { showAnnotations &&

--- a/app/components/Root.jsx
+++ b/app/components/Root.jsx
@@ -193,7 +193,7 @@ class Root extends Component {
                     <HelpButton toggleHelpScreen={() => dispatch(toggleHelpScreen())} /> }
                 </div>
 
-                { isEditor && showSettings && hasSettings && showEditTools && <GraphSettingsForm settings={graphSettings} updateSettings={updateSettings} /> }
+                { (isEditor && showSettings && hasSettings) &&  <GraphSettingsForm settings={graphSettings} updateSettings={updateSettings} /> }
               </div>
             </div>
             { showAnnotations &&

--- a/app/styles/oligrapher.annotations.css
+++ b/app/styles/oligrapher.annotations.css
@@ -217,7 +217,7 @@
   position: absolute;
   display: inline-block;
   z-index: 20;
-  top: 15px;
+  bottom: 15px;
   right: 15px;
   margin: 0 auto;
   text-align: right;


### PR DESCRIPTION
Fixes #40. Removed a statement that returned with null values if showSettings was true (leading me to believe that the fact that only one or the other could be displayed at once was originally intended behaviour--though I agree that that's not intuitive). 

I moved the settings div to the bottom of the graph so that it is not covered by the update forms.

I also made the the ability to show the settings form tied to showEditTools (i.e. user must be in editor/green mode, not annotation/yellow mode in order to see the settings div) to keep the behaviour closer to the initial intended behaviour, though I'm not sure if it's necessary.
